### PR TITLE
Fix Diescraper elevator trigger

### DIFF
--- a/cfg/stripper/acemodrv/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/acemodrv/maps/l4d2_diescraper3_mid_361.cfg
@@ -189,3 +189,31 @@ modify:
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
 }
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
+}

--- a/cfg/stripper/apex/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/apex/maps/l4d2_diescraper3_mid_361.cfg
@@ -189,3 +189,31 @@ modify:
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
 }
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
+}

--- a/cfg/stripper/eq/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/eq/maps/l4d2_diescraper3_mid_361.cfg
@@ -189,3 +189,31 @@ modify:
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
 }
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
+}

--- a/cfg/stripper/nextmod/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/nextmod/maps/l4d2_diescraper3_mid_361.cfg
@@ -15,7 +15,6 @@ filter:
 	"hammerid" "33795"
 }
 
-
 ; Reduce death pits
 modify:
 {
@@ -70,7 +69,6 @@ add:
 	"model" "models/props_mill/mill_railing_64.mdl"
 }
 
-
 ; Reduce delay before store opens up after turning on generator
 ; and make sure tanks can spawn during event
 modify:
@@ -104,7 +102,7 @@ modify:
 	insert:
 	{
 		"OnIn" "directorEndScript1-1"
- 	}
+	}
 }
 
 ; Make sure tanks are enabled and that the horde keeps coming if survivors don't turn off the event
@@ -190,4 +188,32 @@ modify:
 		"OnRandom01" "maze_block5_unblockTrigger0-1"
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
+}
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
 }

--- a/cfg/stripper/pmelite/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/pmelite/maps/l4d2_diescraper3_mid_361.cfg
@@ -189,3 +189,31 @@ modify:
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
 }
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
+}

--- a/cfg/stripper/zonemod/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/zonemod/maps/l4d2_diescraper3_mid_361.cfg
@@ -189,3 +189,31 @@ modify:
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
 }
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
+}

--- a/cfg/stripper/zonemodold/maps/l4d2_diescraper3_mid_361.cfg
+++ b/cfg/stripper/zonemodold/maps/l4d2_diescraper3_mid_361.cfg
@@ -189,3 +189,31 @@ modify:
 		"OnRandom01" "maze_block3_unblockTrigger0-1"
 	}
 }
+
+; --- Fix tank filter on saferoom door
+modify:
+{
+	match:
+	{
+		"targetname" "tankfilter"
+	}
+	replace:
+	{
+		"filterinfectedclass" "8"
+	}
+}
+; --- Add the same trigger on the inside to prevent tank getting stuck
+add:
+{
+	"model" "*187"
+	"wait" "11"
+	"StartDisabled" "0"
+	"spawnflags" "3"
+	"origin" "320 232 -1770.5"
+	"filtername" "tankfilter"
+	"entireteam" "3"
+	"allowincap" "0"
+	"allowghost" "0"
+	"classname" "trigger_multiple"
+	"OnStartTouch" "elevator_door_relayTrigger0-1"
+}


### PR DESCRIPTION
> Fix filter that was supposed to allow tanks to open the elevator for Diescraper version 361
> Tanks can now open the elevator doors if survivors try to cheese the tank by staying inside