### PR TITLE
Zonemod and Acemod v20 Map Changes

### DIFF
--- a/addons/sourcemod/configs/matchmodes.txt
+++ b/addons/sourcemod/configs/matchmodes.txt
@@ -64,7 +64,7 @@
 	{
 		"acemodrv"
 		{
-			"name" "Acemod RV 1.1"
+			"name" "Acemod RV 1.2"
 		}
 		"amrv3v3"
 		{

--- a/addons/sourcemod/configs/saferoominfo.txt
+++ b/addons/sourcemod/configs/saferoominfo.txt
@@ -942,4 +942,37 @@
 		"start_loc_a"	"-3968 3916 -20"
 		"start_loc_b"	"-3084 4720 -344"
 	}
+	"dprm1_milltown_a"
+	{
+		"start_loc_a"	"-7216 8656 239"
+		"start_loc_b"	"-6348 7408 75"
+		"end_loc_a"	"3744 -1440 360"
+		"end_loc_b"	"4224 -1844 104"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_loc_a"	"3744 -1440 360"
+		"start_loc_b"	"4224 -1844 104"
+		"end_loc_a"	"-1919 -13584 258"
+		"end_loc_b"	"-1663 -13840 130"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_loc_a"	"-1919 -13584 258"
+		"start_loc_b"	"-1663 -13840 130"
+		"end_loc_a"	"3744 -1440 360"
+		"end_loc_b"	"4224 -1844 104"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_loc_a"	"3744 -1440 360"
+		"start_loc_b"	"4224 -1844 104"
+		"end_loc_a"	"-3968 3916 -20"
+		"end_loc_b"	"-3084 4720 -344"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_loc_a"	"-3682 8060 281"
+		"start_loc_b"	"-2850 7644 119"
+	}
 }

--- a/cfg/cfgogl/acemodrv/confogl.cfg
+++ b/cfg/cfgogl/acemodrv/confogl.cfg
@@ -8,7 +8,7 @@
 // =======================================================================================
 
 // ReadyUp Cvars
-l4d_ready_cfg_name "Acemod RV 1.1"
+l4d_ready_cfg_name "Acemod RV 1.2"
 
 // Confogl Cvars
 confogl_addcvar mp_gamemode "versus"  // Force Versus for the config.

--- a/cfg/cfgogl/acemodrv/mapinfo.txt
+++ b/cfg/cfgogl/acemodrv/mapinfo.txt
@@ -2260,7 +2260,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2270,6 +2269,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/amrv1v1/confogl.cfg
+++ b/cfg/cfgogl/amrv1v1/confogl.cfg
@@ -8,7 +8,7 @@
 // =======================================================================================
 
 // ReadyUp Cvars
-l4d_ready_cfg_name "1v1 Acemod RV 1.1"
+l4d_ready_cfg_name "1v1 Acemod RV 1.2"
 
 // Confogl Cvars
 confogl_addcvar mp_gamemode "versus"  // Force Versus for the config.

--- a/cfg/cfgogl/amrv1v1/mapinfo.txt
+++ b/cfg/cfgogl/amrv1v1/mapinfo.txt
@@ -2260,7 +2260,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2270,6 +2269,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/amrv2v2/confogl.cfg
+++ b/cfg/cfgogl/amrv2v2/confogl.cfg
@@ -8,7 +8,7 @@
 // =======================================================================================
 
 // ReadyUp Cvars
-l4d_ready_cfg_name "2v2 Acemod RV 1.1"
+l4d_ready_cfg_name "2v2 Acemod RV 1.2"
 
 // Confogl Cvars
 confogl_addcvar mp_gamemode "versus"  // Force Versus for the config.

--- a/cfg/cfgogl/amrv2v2/mapinfo.txt
+++ b/cfg/cfgogl/amrv2v2/mapinfo.txt
@@ -2260,7 +2260,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2270,6 +2269,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/amrv3v3/confogl.cfg
+++ b/cfg/cfgogl/amrv3v3/confogl.cfg
@@ -8,7 +8,7 @@
 // =======================================================================================
 
 // ReadyUp Cvars
-l4d_ready_cfg_name "3v3 Acemod RV 1.1"
+l4d_ready_cfg_name "3v3 Acemod RV 1.2"
 
 // Confogl Cvars
 confogl_addcvar mp_gamemode "versus"  // Force Versus for the config.

--- a/cfg/cfgogl/amrv3v3/mapinfo.txt
+++ b/cfg/cfgogl/amrv3v3/mapinfo.txt
@@ -2260,7 +2260,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2270,6 +2269,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zh1v1/mapinfo.txt
+++ b/cfg/cfgogl/zh1v1/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zh2v2/mapinfo.txt
+++ b/cfg/cfgogl/zh2v2/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zh3v3/mapinfo.txt
+++ b/cfg/cfgogl/zh3v3/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zm1v1/mapinfo.txt
+++ b/cfg/cfgogl/zm1v1/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zm2v2/mapinfo.txt
+++ b/cfg/cfgogl/zm2v2/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zm3v3/mapinfo.txt
+++ b/cfg/cfgogl/zm3v3/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zonehunters/mapinfo.txt
+++ b/cfg/cfgogl/zonehunters/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zonemod/mapinfo.txt
+++ b/cfg/cfgogl/zonemod/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/cfgogl/zoneretro/mapinfo.txt
+++ b/cfg/cfgogl/zoneretro/mapinfo.txt
@@ -2255,7 +2255,6 @@
 		"start_dist"		"100.000000"
 		"start_extra_dist"	"300.000000"
 		"end_dist"			"500.000000"
-		"max_distance"		"500"
 		"horde_limit"		"150"
 	}
 	"dkr_m5_stadium"
@@ -2265,6 +2264,50 @@
 		"start_dist"		"200.000000"
 		"start_extra_dist"	"500.000000"
 		"end_dist"			"150.000000"
+		"ItemLimits"
+		{
+			"pain_pills"	"4"
+		}
+	}
+	"dprm1_milltown_a"
+	{
+		"start_point"		"-6588.341797 7675.165527 96.038345"
+		"end_point"			"3935.251953 -1573.986206 232.281250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm2_sugarmill_a"
+	{
+		"start_point"		"3735.611084 -1667.831177 232.031250"
+		"end_point"			"-1797.393066 -13707.108398 130.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"0.000000"
+		"end_dist"			"200.000000"
+	}
+	"dprm3_sugarmill_b"
+	{
+		"start_point"		"-1788.631592 -13717.489258 130.031250"
+		"end_point"			"3730.589844 -1674.089966 232.031250"
+		"start_dist"		"200.000000"
+		"start_extra_dist"	"000.000000"
+		"end_dist"			"300.000000"
+	}
+	"dprm4_milltown_b"
+	{
+		"start_point"		"3953.058594 -1562.972290 232.281250"
+		"end_point"			"-3217.998291 7792.274902 120.031250"
+		"start_dist"		"300.000000"
+		"start_extra_dist"	"100.000000"
+		"end_dist"			"500.000000"
+	}
+	"dprm5_milltown_escape"
+	{
+		"start_point"		"-3455.657471 7796.145020 120.031250"
+		"end_point"			"-6443.983887 6488.218262 100.031250"
+		"start_dist"		"500.000000"
+		"start_extra_dist"	"200.000000"
+		"end_dist"			"100.000000"
 		"ItemLimits"
 		{
 			"pain_pills"	"4"

--- a/cfg/stripper/acemodrv/maps/c10m1_caves.cfg
+++ b/cfg/stripper/acemodrv/maps/c10m1_caves.cfg
@@ -402,9 +402,9 @@ add:
 ; --- Right side of the bridge valley
 {
 	"classname" "env_physics_blocker"
-	"origin" "-9568 -11680 0"
-	"mins" "-864 -1312 -512"
-	"maxs" "864 1312 512"
+	"origin" "-9568 -11680 384"
+	"mins" "-864 -1312 -896"
+	"maxs" "864 1312 896"
 	"initialstate" "1"
 	"BlockType" "0"
 }
@@ -766,6 +766,50 @@ add:
 	"classname" "func_brush"
 	"origin" "-12373 -14105 -83"
 	"targetname" "los_saferoom_bus_b"
+}
+; --- Tree to cross between cliffs in the valley to get above the saferoom
+{
+	"classname" "prop_dynamic"
+	"origin" "-11104 -11119 393"
+	"angles" "44 270 0"
+	"model" "models/props_foliage/tree_cliff_01a.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11102 -11097 394"
+	"mins" "-24 -56 -8"
+	"maxs" "24 56 8"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11110 -11264 468"
+	"angles" "0 0 -34"
+	"mins" "-19 -149 -8"
+	"maxs" "19 149 8"
+	"boxmins" "-19 -149 -8"
+	"boxmaxs" "19 149 8"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11110 -11419 550"
+	"mins" "-19 -36 -8"
+	"maxs" "19 36 8"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-11139 -11832 509"
+	"angles" "0 65 180"
+	"model" "models/props/cs_militia/militiarock06.mdl"
+	"solid" "6"
+	"disableshadows" "1"
 }
 
 ; =====================================================

--- a/cfg/stripper/acemodrv/maps/c11m3_garage.cfg
+++ b/cfg/stripper/acemodrv/maps/c11m3_garage.cfg
@@ -1473,6 +1473,27 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
+; --- Infected ladders to climb up some pipes in the back of the construction site
+{
+	"classname" "func_simpleladder"
+	"origin" "-2732 -3248.5 -393"
+	"angles" "0 0 0"
+	"model" "*101"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-12164 -115.5 -393"
+	"angles" "0 180 0"
+	"model" "*101"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to climb over fence behind the power station by the van
 {
 	"classname" "func_simpleladder"

--- a/cfg/stripper/acemodrv/maps/c14m1_junkyard.cfg
+++ b/cfg/stripper/acemodrv/maps/c14m1_junkyard.cfg
@@ -278,6 +278,26 @@ modify:
 ; ==             LADDER ADDITIONS / FIXES            ==
 ; ==              Add or change ladders              ==
 ; =====================================================
+add:
+; --- Survivor ladder at the house one-way drop
+{
+	"classname" "func_simpleladder"
+	"origin" "1413 -3906.8 -357"
+	"angles" "0 0 6.5"
+	"model" "*18"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.11"
+	"team" "0"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-1103 -4650 -243"
+	"angles" "6.5 270 0"
+	"model" "models/props/de_train/ladderaluminium.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
 
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######

--- a/cfg/stripper/acemodrv/maps/c2m1_highway.cfg
+++ b/cfg/stripper/acemodrv/maps/c2m1_highway.cfg
@@ -964,7 +964,7 @@ add:
 {
 	"classname" "prop_dynamic"
 	"origin" "8517 8550 -620"
-	"angles" "-3.39422 326.916 1.34152"
+	"angles" "-3 327 2"
 	"model" "models/props_foliage/urban_tree_giant02.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -1234,15 +1234,6 @@ add:
 	"maxs" "115.5 12 1.15"
 	"initialstate" "1"
 	"BlockType" "0"
-}
-; --- Shrub on island before the final hill
-{
-	"classname" "prop_dynamic"
-	"origin" "-1711 1326 -1791"
-	"angles" "0 90 0"
-	"model" "models/props_foliage/swamp_shrubwall_block_256_deep.mdl"
-	"solid" "6"
-	"disableshadows" "1"
 }
 ; --- Tree in back corner before the final hill
 {

--- a/cfg/stripper/acemodrv/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/acemodrv/maps/c2m2_fairgrounds.cfg
@@ -1280,22 +1280,22 @@ add:
 	"disableshadows" "1"
 }
 ; --- Fence under platforms before the carousel
-{
-	"classname" "prop_dynamic"
-	"origin" "-1855 -4478 -121"
-	"angles" "0 90 0"
-	"model" "models/props_urban/fence001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-1855 -4478 -121"
-	"angles" "0 90 0"
-	"model" "models/props_urban/fence_cover001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
+;{
+;	"classname" "prop_dynamic"
+;	"origin" "-1855 -4478 -121"
+;	"angles" "0 90 0"
+;	"model" "models/props_urban/fence001_128.mdl"
+;	"solid" "6"
+;	"disableshadows" "1"
+;}
+;{
+;	"classname" "prop_dynamic"
+;	"origin" "-1855 -4478 -121"
+;	"angles" "0 90 0"
+;	"model" "models/props_urban/fence_cover001_128.mdl"
+;	"solid" "6"
+;	"disableshadows" "1"
+;}
 ; --- Vending machine under platforms before the carousel - Removed due to "Carousel Room" being open
 ;{
 ;	"classname" "prop_dynamic"

--- a/cfg/stripper/acemodrv/maps/c5m2_park.cfg
+++ b/cfg/stripper/acemodrv/maps/c5m2_park.cfg
@@ -905,11 +905,6 @@ add:
 	"origin" "-6272 -4116 -272"
 	"targetname" "path_wall_lighting2"
 }
-{
-	"classname" "info_target"
-	"origin" "-7954 -744 -204"
-	"targetname" "platform_right_lighting"
-}
 ; --- PARK PROPS - LEFT SIDE
 ; --- Extend wall and hedges by the stairs leading into the park on the left
 {
@@ -1196,23 +1191,6 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Extend a hedge by exit to the middle section of the park on the left side
-{
-	"classname" "prop_dynamic"
-	"origin" "-7243 -2727 -260"
-	"angles" "0 0 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-7243 -2727 700"
-	"mins" "-125 -22 -964"
-	"maxs" "125 22 964"
-	"initialstate" "1"
-	"BlockType" "1"
-}
 ; --- PARK PROPS - RIGHT SIDE
 ; --- Extend line of small hedges by the stairs on the right side
 {
@@ -1244,14 +1222,6 @@ add:
 {
 	"classname" "prop_dynamic"
 	"origin" "-6031 -1271 -253"
-	"angles" "0 67.5 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-5937 -1045 -242"
 	"angles" "0 67.5 0"
 	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
 	"solid" "6"
@@ -1316,113 +1286,6 @@ add:
 	"maxs" "20 127 896"
 	"initialstate" "1"
 	"BlockType" "1"
-}
-; --- Platform by wall before restrooms on the right side
-{
-	"classname" "prop_dynamic"
-	"origin" "-6452 -309 -256"
-	"angles" "0 270 0"
-	"model" "models/props_urban/gate_wall001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6376 -309 -256"
-	"angles" "0 270 0"
-	"model" "models/props_urban/gate_column001_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6376 -233 -256"
-	"angles" "0 180 0"
-	"model" "models/props_urban/gate_wall001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6449 -233 -174"
-	"angles" "0 0 0"
-	"model" "models/props_update/concrete_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6448 -294 -192"
-	"angles" "0 0 0"
-	"model" "models/props_foliage/urban_hedge_128_64_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6453 -314 -139"
-	"mins" "-64 -3 -5"
-	"maxs" "64 3 5"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6453 -304 -131"
-	"mins" "-64 -7 -3"
-	"maxs" "64 7 3"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6391 -224 -192"
-	"angles" "0 90 0"
-	"model" "models/props_foliage/urban_hedge_128_64_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6371 -233 -139"
-	"mins" "-3 -64 -5"
-	"maxs" "3 64 5"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6381 -233 -131"
-	"mins" "-7 -64 -3"
-	"maxs" "7 64 3"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6442 -245 672"
-	"mins" "-78 -77 -992"
-	"maxs" "78 77 992"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Move an item spawn that would otherwise spawn inside the platform
-modify:
-{
-	match:
-	{
-		"hammerid" "2304517"
-	}
-	replace:
-	{
-		"origin" "-6341 -208 -215"
-	}
 }
 ; --- Foliage on right side of park
 add:

--- a/cfg/stripper/acemodrv/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/acemodrv/maps/c6m1_riverbank.cfg
@@ -515,12 +515,20 @@ add:
 ; --- Block survivors from standing on the fallen bus
 {
 	"classname" "env_physics_blocker"
-	"origin" "2733 3207 1562"
-	"angles" "0 131.509 0"
-	"mins" "-236 -52 -1428"
-	"maxs" "236 52 1428"
-	"boxmins" "-236 -52 -1428"
-	"boxmaxs" "236 52 1428"
+	"origin" "2737 3209 154"
+	"angles" "16 131.509 7.1"
+	"mins" "-236 -52 0"
+	"maxs" "236 52 40"
+	"boxmins" "-236 -52 0"
+	"boxmaxs" "236 52 40"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2564 3330 120"
+	"mins" "-16 -10 -24"
+	"maxs" "16 10 24"
 	"initialstate" "1"
 	"BlockType" "1"
 }

--- a/cfg/stripper/acemodrv/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/acemodrv/maps/c6m1_riverbank.cfg
@@ -65,6 +65,117 @@ add:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
+; --- Fix car that spawns inside truck that can incap players if something displaces it
+modify:
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_car1"
+	}
+	replace:
+	{
+		"origin" "3535.35 2880.31 44.073"
+	}
+}
+{
+	match:
+	{
+		"parentname" "caralarm_4-caralarm_car1"
+		"origin" "3519.35 2880.31 40.073"
+	}
+	replace:
+	{
+		"origin" "3535.35 2880.31 44.073"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3577.79 2973.33 71.168"
+	}
+	replace:
+	{
+		"origin" "3593.79 2973.33 75.168"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3616.68 2932.07 71.169"
+	}
+	replace:
+	{
+		"origin" "3632.68 2932.07 75.169"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3422.15 2843.06 69.031"
+	}
+	replace:
+	{
+		"origin" "3438.15 2843.06 73.031"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3422.15 2843.06 69.031"
+	}
+	replace:
+	{
+		"origin" "3438.15 2843.06 73.031"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3474.17 2786.3 69"
+	}
+	replace:
+	{
+		"origin" "3490.17 2786.3 73"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_headlights1"
+		"origin" "3425.3 2833.74 69.679"
+	}
+	replace:
+	{
+		"origin" "3441.3 2833.74 73.679"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_headlights1"
+		"origin" "3464.48 2790.98 69.693"
+	}
+	replace:
+	{
+		"origin" "3480.48 2790.98 73.693"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-maker_alarm_on"
+		"origin" "3511.65 2883.2 191.703"
+	}
+	replace:
+	{
+		"origin" "3527.65 2883.2 195.703"
+	}
+}
 ; --- Make various cars unhittable due to large number of hittable cars
 ; --- Saferoom
 filter:

--- a/cfg/stripper/acemodrv/maps/c7m2_barge.cfg
+++ b/cfg/stripper/acemodrv/maps/c7m2_barge.cfg
@@ -279,10 +279,6 @@ filter:
 ; ==    Fix triggers that interfere with gameplay    ==
 ; =====================================================
 filter:
-; --- Remove forced slow movement on the gravel pile
-;{
-;	"targetname" "gravelpile_playermovement"
-;}
 ; --- Remove slow movement trigger in water after barge that Valve forgot to remove from the L4D2 port
 {
 	"hammerid" "2536834"

--- a/cfg/stripper/acemodrv/maps/dprm1_milltown_a.cfg
+++ b/cfg/stripper/acemodrv/maps/dprm1_milltown_a.cfg
@@ -1,5 +1,82 @@
-; --- Block jumping on house by the playground
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+; --- Fix starting saferoom nav not being applied (newest version)
+modify:
+{
+	match:
+	{
+		"hammerid" "4326660"
+	}
+	replace:
+	{
+		"spawnflags" "10370"
+	}
+}
+
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Pistols on the docks
 add:
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6933 7745 148"
+	"angles" "0 255 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6934 7761 148"
+	"angles" "0 270 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
+; --- Remove out of bounds weapon spawns (newest version)
+filter:
+{
+	"hammerid" "740143"
+}
+{
+	"hammerid" "740141"
+}
+{
+	"hammerid" "740135"
+}
+{
+	"hammerid" "740137"
+}
+{
+	"hammerid" "740139"
+}
+{
+	"hammerid" "740145"
+}
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from jumping on house by the playground
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1473 7605 958"
@@ -16,3 +93,221 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+; --- Allow any infected to break the Save 4 Less store windows
+modify:
+{
+	match:
+	{
+		"targetname" "glass_1s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_2s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_3s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_4s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+modify:
+; --- Fix broken ladder on Self Storage building (old version)
+{
+	match:
+	{
+		"hammerid" "19283"
+	}
+	replace:
+	{
+		"normal.x" "-1.00"
+		"normal.y" "0.00"
+	}
+}
+; --- Fix broken ladder on broken fence after the burger tank (newest version)
+{
+	match:
+	{
+		"hammerid" "1639791"
+	}
+	insert:
+	{
+		"origin" "0 4 0"
+	}
+}
+; --- Fix broken ladders on house by the playground (newest version)
+{
+	match:
+	{
+		"hammerid" "2591916"
+	}
+	insert:
+	{
+		"origin" "0 1 0"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "2591878"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix broken ladders on house by the playground (old version)
+{
+	match:
+	{
+		"hammerid" "24123"
+	}
+	insert:
+	{
+		"origin" "0 1 0"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "24120"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix broken ladder by garage sale (newest version)
+{
+	match:
+	{
+		"hammerid" "4273049"
+	}
+	insert:
+	{
+		"origin" "1 0 0"
+	}
+}
+; --- Fix broken infected ladder by the one-way drop house (old version) (credit: Wicket)
+add:
+{
+	"classname" "func_simpleladder"
+	"origin" "9905.00 2248.00 -88.00"
+	"angles" "0 90 0"
+	"model" "*191"
+	"normal.x" "0.86"
+	"normal.y" "0.00"
+	"normal.z" "-0.50"
+	"team" "2"
+	"rendermode" "10" ; --- On newest this is visible in an incorrect spot so hide it
+}
+; --- Infected ladder to climb on the house by the flower garden (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-3111 -227.5 203"
+	"angles" "0 270 0"
+	"model" "*153"
+	"normal.x" "0.00"
+	"normal.y" "0.89"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+; --- Infected ladder to climb on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1712 -1870 -28"
+	"angles" "0 270 0"
+	"model" "*179"
+	"normal.x" "0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/acemodrv/maps/dprm2_sugarmill_a.cfg
+++ b/cfg/stripper/acemodrv/maps/dprm2_sugarmill_a.cfg
@@ -1,53 +1,175 @@
-; Map name: dprm2_downpour_a
+; ############  DIRECTOR AND EVENT CHANGES  ###########
 ; =====================================================
-; =========== PROMOD USELESS PILL REMOVAL =============
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
 ; =====================================================
+; --- Fix multiple unwanted witches being spawned
 filter:
-{"hammerid" "6463708"}
-{"hammerid" "6463710"}
-{"hammerid" "6463712"}
-{"hammerid" "6463714"}
-{"hammerid" "6463716"}
-{"hammerid" "6463718"}
-{"hammerid" "6463720"}
-{"hammerid" "6463722"}
-{"hammerid" "6463724"}
-{"hammerid" "6463726"}
-{"hammerid" "6463728"}
-{"hammerid" "6463730"}
-{"hammerid" "6463732"}
-{"hammerid" "6463734"}
-{"hammerid" "6463736"}
-{"hammerid" "6463738"}
-{"hammerid" "6463740"}
-{"hammerid" "6463742"}
-{"hammerid" "6463744"}
-{"hammerid" "6463746"}
-{"hammerid" "6463748"}
-{"hammerid" "6463750"}
-{"hammerid" "6463752"}
-{"hammerid" "6463754"}
-{"hammerid" "6463756"}
-{"hammerid" "6463758"}
-{"hammerid" "6463760"}
-{"hammerid" "6463762"}
-{"hammerid" "6463764"}
-{"hammerid" "6463766"}
-{"hammerid" "6463768"}
-{"hammerid" "6463770"}
-{"hammerid" "6463772"}
-{"hammerid" "6463774"}
-
-; --- filter out bugged witches in 1v1
-
-filter:
-
 {
 	"targetname" "spawn_witch"
 }
 
-; --- Block jumping on gas station roof
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Remove out of bounds items (old version only)
+filter:
+{
+	"hammerid" "6463708"
+}
+{
+	"hammerid" "6463710"
+}
+{
+	"hammerid" "6463712"
+}
+{
+	"hammerid" "6463714"
+}
+{
+	"hammerid" "6463716"
+}
+{
+	"hammerid" "6463718"
+}
+{
+	"hammerid" "6463720"
+}
+{
+	"hammerid" "6463722"
+}
+{
+	"hammerid" "6463724"
+}
+{
+	"hammerid" "6463726"
+}
+{
+	"hammerid" "6463728"
+}
+{
+	"hammerid" "6463730"
+}
+{
+	"hammerid" "6463732"
+}
+{
+	"hammerid" "6463734"
+}
+{
+	"hammerid" "6463736"
+}
+{
+	"hammerid" "6463738"
+}
+{
+	"hammerid" "6463740"
+}
+{
+	"hammerid" "6463742"
+}
+{
+	"hammerid" "6463744"
+}
+{
+	"hammerid" "6463746"
+}
+{
+	"hammerid" "6463748"
+}
+{
+	"hammerid" "6463750"
+}
+{
+	"hammerid" "6463752"
+}
+{
+	"hammerid" "6463754"
+}
+{
+	"hammerid" "6463756"
+}
+{
+	"hammerid" "6463758"
+}
+{
+	"hammerid" "6463760"
+}
+{
+	"hammerid" "6463762"
+}
+{
+	"hammerid" "6463764"
+}
+{
+	"hammerid" "6463766"
+}
+{
+	"hammerid" "6463768"
+}
+{
+	"hammerid" "6463770"
+}
+{
+	"hammerid" "6463772"
+}
+{
+	"hammerid" "6463774"
+}
+{
+	"hammerid" "6496351"
+}
+{
+	"hammerid" "6496347"
+}
+{
+	"hammerid" "6531608"
+}
+{
+	"hammerid" "6496357"
+}
+{
+	"hammerid" "6496363"
+}
+{
+	"hammerid" "6496359"
+}
+{
+	"hammerid" "6496361"
+}
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
 add:
+; --- Ammo pile in the office by the silos
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "-1005 -7913 111"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from jumping on gas station roof
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1593 -13616 894"
@@ -64,3 +186,192 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+add:
+; --- Fix non-solid trees by the silos
+{
+	"classname" "prop_dynamic"
+	"origin" "-1237 -7354 97"
+	"angles" "0 220 0"
+	"model" "models/props_foliage/urban_tree_giant01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "355 -8630 97"
+	"angles" "0 213.5 0"
+	"model" "models/props_foliage/urban_tree_giant01_small.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+; --- Block jumping onto one of the trees
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1068 -7395 1273"
+	"mins" "-35 -35 -841"
+	"maxs" "35 35 841"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Clipping between truck and roof by the silos
+{
+	"classname" "env_physics_blocker"
+	"origin" "280 -8192 267"
+	"mins" "-3 -51 -5"
+	"maxs" "3 51 5"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "286 -8192 276"
+	"mins" "-3 -51 -4"
+	"maxs" "3 51 4"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder to get on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "7240 1747 -6.5"
+	"angles" "0 270 0"
+	"model" "*211"
+	"normal.x" "-1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to get on the awning in the construction site (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*213"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*214"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+; --- Infected ladder to climb on the generator room roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1721 1242 41"
+	"angles" "0 0 0"
+	"model" "*70"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the pipe outside the generator room (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1628 0 0"
+	"angles" "0 0 0"
+	"model" "*57"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the larger slanted roof by the silos (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-438 -1006 -4"
+	"angles" "0 0 0"
+	"model" "*64"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Fix a badly placed ladder by the office in the mill (all versions)
+modify:
+{
+	match:
+	{
+		"hammerid" "3484921"
+	}
+	insert:
+	{
+		"origin" "2 0 3"
+	}
+}
+
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/acemodrv/maps/dprm3_sugarmill_b.cfg
+++ b/cfg/stripper/acemodrv/maps/dprm3_sugarmill_b.cfg
@@ -1,5 +1,55 @@
-; --- Block jumping on gas station roof
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
 add:
+; --- Ammo pile in the train yard
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "455 -11656 198"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+; --- Ammo pile in the office by the silos
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "-1005 -7913 111"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block jumping on gas station roof
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1593 -13616 894"
@@ -16,3 +66,213 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+add:
+; --- Fix non-solid trees by the silos
+{
+	"classname" "prop_dynamic"
+	"origin" "-1237 -7354 97"
+	"angles" "0 220 0"
+	"model" "models/props_foliage/urban_tree_giant01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "355 -8630 97"
+	"angles" "0 213.5 0"
+	"model" "models/props_foliage/urban_tree_giant01_small.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+; --- Block jumping onto one of the trees
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1068 -7395 1273"
+	"mins" "-35 -35 -841"
+	"maxs" "35 35 841"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Clipping between truck and roof by the silos
+{
+	"classname" "env_physics_blocker"
+	"origin" "280 -8192 267"
+	"mins" "-3 -51 -5"
+	"maxs" "3 51 5"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "286 -8192 276"
+	"mins" "-3 -51 -4"
+	"maxs" "3 51 4"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder to get on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "3562 8946 -37"
+	"angles" "0 0 0"
+	"model" "*176"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+; --- Infected ladder to get on the awning in the construction site (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*272"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*273"
+	"normal.x" "-1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the generator room roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1721 1242 41"
+	"angles" "0 0 0"
+	"model" "*63"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the pipe outside the generator room (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "3668 -8701 16"
+	"angles" "0 180 0"
+	"model" "*53"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the larger slanted roof by the silos (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-438 -1006 -4"
+	"angles" "0 0 0"
+	"model" "*228"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the bridge by the bricks (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "10407 -7709 24"
+	"angles" "0 270 0"
+	"model" "*271"
+	"normal.x" "0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "10407 -7709 24"
+	"angles" "0 270 0"
+	"model" "*270"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Fix a badly placed ladder by the office in the mill (all versions)
+modify:
+{
+	match:
+	{
+		"hammerid" "3484921"
+	}
+	insert:
+	{
+		"origin" "2 0 3"
+	}
+}
+
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/acemodrv/maps/dprm5_milltown_escape.cfg
+++ b/cfg/stripper/acemodrv/maps/dprm5_milltown_escape.cfg
@@ -10,6 +10,22 @@
 ; ==           PILL / ITEM / WEAPON SPAWNS           ==
 ; ==   Remove or change pill, item & weapon spawns   ==
 ; =====================================================
+; --- Pistols on the docks
+add:
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6933 7745 148"
+	"angles" "0 255 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6934 7761 148"
+	"angles" "0 270 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -27,24 +43,6 @@
 ; ==                 EXPLOITS BLOCKED                ==
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
-add:
-; --- Block survivors from jumping on house by the playground
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1473 7605 958"
-	"mins" "-176 -376 -626"
-	"maxs" "176 376 626"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1817 7805 958"
-	"mins" "-168 -176 -626"
-	"maxs" "168 176 626"
-	"initialstate" "1"
-	"BlockType" "1"
-}
 
 ; =====================================================
 ; ==                  OUT OF BOUNDS                  ==
@@ -60,6 +58,48 @@ add:
 ; ==                 NUISANCE CHANGES                ==
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
+; --- Allow any infected to break the Save 4 Less store windows
+modify:
+{
+	match:
+	{
+		"targetname" "glass_1s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_2s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_3s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_4s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -104,6 +144,18 @@ add:
 ; ==              Add or change ladders              ==
 ; =====================================================
 modify:
+; --- Fix broken ladder on Self Storage building (old version)
+{
+	match:
+	{
+		"hammerid" "6996"
+	}
+	replace:
+	{
+		"normal.x" "-1.00"
+		"normal.y" "0.00"
+	}
+}
 ; --- Fix broken ladder on broken fence after the burger tank (newest version)
 {
 	match:
@@ -114,95 +166,6 @@ modify:
 	{
 		"origin" "0 4 0"
 	}
-}
-; --- Fix broken ladders on house by the playground (newest version)
-{
-	match:
-	{
-		"hammerid" "2591916"
-	}
-	insert:
-	{
-		"origin" "0 1 0"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "2591878"
-	}
-	insert:
-	{
-		"origin" "0 -1 0"
-	}
-}
-; --- Fix broken ladders on house by the playground (old version)
-; --- Move ladder to a different spot due to badly placed clip brush
-{
-	match:
-	{
-		"hammerid" "8007823"
-	}
-	insert:
-	{
-		"origin" "-70 0 0"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "8007814"
-	}
-	insert:
-	{
-		"origin" "0 -1 0"
-	}
-}
-; --- Fix broken ladder by garage sale (newest version)
-{
-	match:
-	{
-		"hammerid" "4273049"
-	}
-	insert:
-	{
-		"origin" "1 0 0"
-	}
-}
-; --- Fix broken infected ladder by the one-way drop house (old version) (credit: Wicket)
-add:
-{
-	"classname" "func_simpleladder"
-	"origin" "9905.00 2248.00 -88.00"
-	"angles" "0.00 90.00 0.00"
-	"model" "*64"
-	"normal.x" "0.86"
-	"normal.y" "0.00"
-	"normal.z" "-0.50"
-	"team" "2"
-	"rendermode" "10" ; --- On newest this is visible in an incorrect spot so hide it
-}
-; --- Infected ladder to climb on the house by the flower garden (newest version only)
-{
-	"classname" "func_simpleladder"
-	"origin" "1142 58 213"
-	"angles" "0 0 0"
-	"model" "*148"
-	"normal.x" "0.00"
-	"normal.y" "1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-; --- Infected ladder to climb on the sugarmill saferoom roof (newest version only)
-{
-	"classname" "func_simpleladder"
-	"origin" "-1712 -1870 -28"
-	"angles" "0 270 0"
-	"model" "*92"
-	"normal.x" "0.89"
-	"normal.y" "0.00"
-	"normal.z" "-0.44"
-	"team" "2"
 }
 
 

--- a/cfg/stripper/acemodrv/maps/l4d_dbd2dc_the_mall.cfg
+++ b/cfg/stripper/acemodrv/maps/l4d_dbd2dc_the_mall.cfg
@@ -123,6 +123,7 @@ modify:
 	{
 		"OnPressed" "eingangsture,Unlock,,41.05,-1"
 		"OnPressed" "eingangsture,Open,,42,-1"
+		"OnPressed" "eingangsture,SetBreakable,,42,-1"
 		"OnPressed" "director,PanicEvent,,4,-1"
 		"OnPressed" "cj_door_open,PlaySound,,42.1,-1"
 		"OnPressed" "girl_van,Start,,6,-1"

--- a/cfg/stripper/zonemod/maps/c10m1_caves.cfg
+++ b/cfg/stripper/zonemod/maps/c10m1_caves.cfg
@@ -402,9 +402,9 @@ add:
 ; --- Right side of the bridge valley
 {
 	"classname" "env_physics_blocker"
-	"origin" "-9568 -11680 0"
-	"mins" "-864 -1312 -512"
-	"maxs" "864 1312 512"
+	"origin" "-9568 -11680 384"
+	"mins" "-864 -1312 -896"
+	"maxs" "864 1312 896"
 	"initialstate" "1"
 	"BlockType" "0"
 }
@@ -766,6 +766,50 @@ add:
 	"classname" "func_brush"
 	"origin" "-12373 -14105 -83"
 	"targetname" "los_saferoom_bus_b"
+}
+; --- Tree to cross between cliffs in the valley to get above the saferoom
+{
+	"classname" "prop_dynamic"
+	"origin" "-11104 -11119 393"
+	"angles" "44 270 0"
+	"model" "models/props_foliage/tree_cliff_01a.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11102 -11097 394"
+	"mins" "-24 -56 -8"
+	"maxs" "24 56 8"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11110 -11264 468"
+	"angles" "0 0 -34"
+	"mins" "-19 -149 -8"
+	"maxs" "19 149 8"
+	"boxmins" "-19 -149 -8"
+	"boxmaxs" "19 149 8"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11110 -11419 550"
+	"mins" "-19 -36 -8"
+	"maxs" "19 36 8"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-11139 -11832 509"
+	"angles" "0 65 180"
+	"model" "models/props/cs_militia/militiarock06.mdl"
+	"solid" "6"
+	"disableshadows" "1"
 }
 
 ; =====================================================

--- a/cfg/stripper/zonemod/maps/c11m3_garage.cfg
+++ b/cfg/stripper/zonemod/maps/c11m3_garage.cfg
@@ -1473,6 +1473,27 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
+; --- Infected ladders to climb up some pipes in the back of the construction site
+{
+	"classname" "func_simpleladder"
+	"origin" "-2732 -3248.5 -393"
+	"angles" "0 0 0"
+	"model" "*101"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-12164 -115.5 -393"
+	"angles" "0 180 0"
+	"model" "*101"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to climb over fence behind the power station by the van
 {
 	"classname" "func_simpleladder"

--- a/cfg/stripper/zonemod/maps/c14m1_junkyard.cfg
+++ b/cfg/stripper/zonemod/maps/c14m1_junkyard.cfg
@@ -278,6 +278,26 @@ modify:
 ; ==             LADDER ADDITIONS / FIXES            ==
 ; ==              Add or change ladders              ==
 ; =====================================================
+add:
+; --- Survivor ladder at the house one-way drop
+{
+	"classname" "func_simpleladder"
+	"origin" "1413 -3906.8 -357"
+	"angles" "0 0 6.5"
+	"model" "*18"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.11"
+	"team" "0"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-1103 -4650 -243"
+	"angles" "6.5 270 0"
+	"model" "models/props/de_train/ladderaluminium.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
 
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######

--- a/cfg/stripper/zonemod/maps/c2m1_highway.cfg
+++ b/cfg/stripper/zonemod/maps/c2m1_highway.cfg
@@ -964,7 +964,7 @@ add:
 {
 	"classname" "prop_dynamic"
 	"origin" "8517 8550 -620"
-	"angles" "-3.39422 326.916 1.34152"
+	"angles" "-3 327 2"
 	"model" "models/props_foliage/urban_tree_giant02.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -1234,15 +1234,6 @@ add:
 	"maxs" "115.5 12 1.15"
 	"initialstate" "1"
 	"BlockType" "0"
-}
-; --- Shrub on island before the final hill
-{
-	"classname" "prop_dynamic"
-	"origin" "-1711 1326 -1791"
-	"angles" "0 90 0"
-	"model" "models/props_foliage/swamp_shrubwall_block_256_deep.mdl"
-	"solid" "6"
-	"disableshadows" "1"
 }
 ; --- Tree in back corner before the final hill
 {

--- a/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
@@ -1280,22 +1280,22 @@ add:
 	"disableshadows" "1"
 }
 ; --- Fence under platforms before the carousel
-{
-	"classname" "prop_dynamic"
-	"origin" "-1855 -4478 -121"
-	"angles" "0 90 0"
-	"model" "models/props_urban/fence001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-1855 -4478 -121"
-	"angles" "0 90 0"
-	"model" "models/props_urban/fence_cover001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
+;{
+;	"classname" "prop_dynamic"
+;	"origin" "-1855 -4478 -121"
+;	"angles" "0 90 0"
+;	"model" "models/props_urban/fence001_128.mdl"
+;	"solid" "6"
+;	"disableshadows" "1"
+;}
+;{
+;	"classname" "prop_dynamic"
+;	"origin" "-1855 -4478 -121"
+;	"angles" "0 90 0"
+;	"model" "models/props_urban/fence_cover001_128.mdl"
+;	"solid" "6"
+;	"disableshadows" "1"
+;}
 ; --- Vending machine under platforms before the carousel - Removed due to "Carousel Room" being open
 ;{
 ;	"classname" "prop_dynamic"

--- a/cfg/stripper/zonemod/maps/c5m2_park.cfg
+++ b/cfg/stripper/zonemod/maps/c5m2_park.cfg
@@ -905,11 +905,6 @@ add:
 	"origin" "-6272 -4116 -272"
 	"targetname" "path_wall_lighting2"
 }
-{
-	"classname" "info_target"
-	"origin" "-7954 -744 -204"
-	"targetname" "platform_right_lighting"
-}
 ; --- PARK PROPS - LEFT SIDE
 ; --- Extend wall and hedges by the stairs leading into the park on the left
 {
@@ -1196,23 +1191,6 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Extend a hedge by exit to the middle section of the park on the left side
-{
-	"classname" "prop_dynamic"
-	"origin" "-7243 -2727 -260"
-	"angles" "0 0 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-7243 -2727 700"
-	"mins" "-125 -22 -964"
-	"maxs" "125 22 964"
-	"initialstate" "1"
-	"BlockType" "1"
-}
 ; --- PARK PROPS - RIGHT SIDE
 ; --- Extend line of small hedges by the stairs on the right side
 {
@@ -1244,14 +1222,6 @@ add:
 {
 	"classname" "prop_dynamic"
 	"origin" "-6031 -1271 -253"
-	"angles" "0 67.5 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-5937 -1045 -242"
 	"angles" "0 67.5 0"
 	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
 	"solid" "6"
@@ -1316,113 +1286,6 @@ add:
 	"maxs" "20 127 896"
 	"initialstate" "1"
 	"BlockType" "1"
-}
-; --- Platform by wall before restrooms on the right side
-{
-	"classname" "prop_dynamic"
-	"origin" "-6452 -309 -256"
-	"angles" "0 270 0"
-	"model" "models/props_urban/gate_wall001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6376 -309 -256"
-	"angles" "0 270 0"
-	"model" "models/props_urban/gate_column001_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6376 -233 -256"
-	"angles" "0 180 0"
-	"model" "models/props_urban/gate_wall001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6449 -233 -174"
-	"angles" "0 0 0"
-	"model" "models/props_update/concrete_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6448 -294 -192"
-	"angles" "0 0 0"
-	"model" "models/props_foliage/urban_hedge_128_64_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6453 -314 -139"
-	"mins" "-64 -3 -5"
-	"maxs" "64 3 5"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6453 -304 -131"
-	"mins" "-64 -7 -3"
-	"maxs" "64 7 3"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6391 -224 -192"
-	"angles" "0 90 0"
-	"model" "models/props_foliage/urban_hedge_128_64_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "platform_right_lighting"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6371 -233 -139"
-	"mins" "-3 -64 -5"
-	"maxs" "3 64 5"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6381 -233 -131"
-	"mins" "-7 -64 -3"
-	"maxs" "7 64 3"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-6442 -245 672"
-	"mins" "-78 -77 -992"
-	"maxs" "78 77 992"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Move an item spawn that would otherwise spawn inside the platform
-modify:
-{
-	match:
-	{
-		"hammerid" "2304517"
-	}
-	replace:
-	{
-		"origin" "-6341 -208 -215"
-	}
 }
 ; --- Foliage on right side of park
 add:

--- a/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
@@ -515,12 +515,20 @@ add:
 ; --- Block survivors from standing on the fallen bus
 {
 	"classname" "env_physics_blocker"
-	"origin" "2733 3207 1562"
-	"angles" "0 131.509 0"
-	"mins" "-236 -52 -1428"
-	"maxs" "236 52 1428"
-	"boxmins" "-236 -52 -1428"
-	"boxmaxs" "236 52 1428"
+	"origin" "2737 3209 154"
+	"angles" "16 131.509 7.1"
+	"mins" "-236 -52 0"
+	"maxs" "236 52 40"
+	"boxmins" "-236 -52 0"
+	"boxmaxs" "236 52 40"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2564 3330 120"
+	"mins" "-16 -10 -24"
+	"maxs" "16 10 24"
 	"initialstate" "1"
 	"BlockType" "1"
 }

--- a/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
@@ -65,6 +65,117 @@ add:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
+; --- Fix car that spawns inside truck that can incap players if something displaces it
+modify:
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_car1"
+	}
+	replace:
+	{
+		"origin" "3535.35 2880.31 44.073"
+	}
+}
+{
+	match:
+	{
+		"parentname" "caralarm_4-caralarm_car1"
+		"origin" "3519.35 2880.31 40.073"
+	}
+	replace:
+	{
+		"origin" "3535.35 2880.31 44.073"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3577.79 2973.33 71.168"
+	}
+	replace:
+	{
+		"origin" "3593.79 2973.33 75.168"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3616.68 2932.07 71.169"
+	}
+	replace:
+	{
+		"origin" "3632.68 2932.07 75.169"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3422.15 2843.06 69.031"
+	}
+	replace:
+	{
+		"origin" "3438.15 2843.06 73.031"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3422.15 2843.06 69.031"
+	}
+	replace:
+	{
+		"origin" "3438.15 2843.06 73.031"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_light1"
+		"origin" "3474.17 2786.3 69"
+	}
+	replace:
+	{
+		"origin" "3490.17 2786.3 73"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_headlights1"
+		"origin" "3425.3 2833.74 69.679"
+	}
+	replace:
+	{
+		"origin" "3441.3 2833.74 73.679"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-caralarm_headlights1"
+		"origin" "3464.48 2790.98 69.693"
+	}
+	replace:
+	{
+		"origin" "3480.48 2790.98 73.693"
+	}
+}
+{
+	match:
+	{
+		"targetname" "caralarm_4-maker_alarm_on"
+		"origin" "3511.65 2883.2 191.703"
+	}
+	replace:
+	{
+		"origin" "3527.65 2883.2 195.703"
+	}
+}
 ; --- Make various cars unhittable due to large number of hittable cars
 ; --- Saferoom
 filter:

--- a/cfg/stripper/zonemod/maps/c7m2_barge.cfg
+++ b/cfg/stripper/zonemod/maps/c7m2_barge.cfg
@@ -279,10 +279,6 @@ filter:
 ; ==    Fix triggers that interfere with gameplay    ==
 ; =====================================================
 filter:
-; --- Remove forced slow movement on the gravel pile
-;{
-;	"targetname" "gravelpile_playermovement"
-;}
 ; --- Remove slow movement trigger in water after barge that Valve forgot to remove from the L4D2 port
 {
 	"hammerid" "2536834"

--- a/cfg/stripper/zonemod/maps/dprm1_milltown_a.cfg
+++ b/cfg/stripper/zonemod/maps/dprm1_milltown_a.cfg
@@ -1,5 +1,82 @@
-; --- Block jumping on house by the playground
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+; --- Fix starting saferoom nav not being applied (newest version)
+modify:
+{
+	match:
+	{
+		"hammerid" "4326660"
+	}
+	replace:
+	{
+		"spawnflags" "10370"
+	}
+}
+
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Pistols on the docks
 add:
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6933 7745 148"
+	"angles" "0 255 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6934 7761 148"
+	"angles" "0 270 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
+; --- Remove out of bounds weapon spawns (newest version)
+filter:
+{
+	"hammerid" "740143"
+}
+{
+	"hammerid" "740141"
+}
+{
+	"hammerid" "740135"
+}
+{
+	"hammerid" "740137"
+}
+{
+	"hammerid" "740139"
+}
+{
+	"hammerid" "740145"
+}
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from jumping on house by the playground
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1473 7605 958"
@@ -16,3 +93,221 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+; --- Allow any infected to break the Save 4 Less store windows
+modify:
+{
+	match:
+	{
+		"targetname" "glass_1s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_2s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_3s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_4s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+modify:
+; --- Fix broken ladder on Self Storage building (old version)
+{
+	match:
+	{
+		"hammerid" "19283"
+	}
+	replace:
+	{
+		"normal.x" "-1.00"
+		"normal.y" "0.00"
+	}
+}
+; --- Fix broken ladder on broken fence after the burger tank (newest version)
+{
+	match:
+	{
+		"hammerid" "1639791"
+	}
+	insert:
+	{
+		"origin" "0 4 0"
+	}
+}
+; --- Fix broken ladders on house by the playground (newest version)
+{
+	match:
+	{
+		"hammerid" "2591916"
+	}
+	insert:
+	{
+		"origin" "0 1 0"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "2591878"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix broken ladders on house by the playground (old version)
+{
+	match:
+	{
+		"hammerid" "24123"
+	}
+	insert:
+	{
+		"origin" "0 1 0"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "24120"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix broken ladder by garage sale (newest version)
+{
+	match:
+	{
+		"hammerid" "4273049"
+	}
+	insert:
+	{
+		"origin" "1 0 0"
+	}
+}
+; --- Fix broken infected ladder by the one-way drop house (old version) (credit: Wicket)
+add:
+{
+	"classname" "func_simpleladder"
+	"origin" "9905.00 2248.00 -88.00"
+	"angles" "0 90 0"
+	"model" "*191"
+	"normal.x" "0.86"
+	"normal.y" "0.00"
+	"normal.z" "-0.50"
+	"team" "2"
+	"rendermode" "10" ; --- On newest this is visible in an incorrect spot so hide it
+}
+; --- Infected ladder to climb on the house by the flower garden (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-3111 -227.5 203"
+	"angles" "0 270 0"
+	"model" "*153"
+	"normal.x" "0.00"
+	"normal.y" "0.89"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+; --- Infected ladder to climb on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1712 -1870 -28"
+	"angles" "0 270 0"
+	"model" "*179"
+	"normal.x" "0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/zonemod/maps/dprm2_sugarmill_a.cfg
+++ b/cfg/stripper/zonemod/maps/dprm2_sugarmill_a.cfg
@@ -1,53 +1,175 @@
-; Map name: dprm2_downpour_a
+; ############  DIRECTOR AND EVENT CHANGES  ###########
 ; =====================================================
-; =========== PROMOD USELESS PILL REMOVAL =============
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
 ; =====================================================
+; --- Fix multiple unwanted witches being spawned
 filter:
-{"hammerid" "6463708"}
-{"hammerid" "6463710"}
-{"hammerid" "6463712"}
-{"hammerid" "6463714"}
-{"hammerid" "6463716"}
-{"hammerid" "6463718"}
-{"hammerid" "6463720"}
-{"hammerid" "6463722"}
-{"hammerid" "6463724"}
-{"hammerid" "6463726"}
-{"hammerid" "6463728"}
-{"hammerid" "6463730"}
-{"hammerid" "6463732"}
-{"hammerid" "6463734"}
-{"hammerid" "6463736"}
-{"hammerid" "6463738"}
-{"hammerid" "6463740"}
-{"hammerid" "6463742"}
-{"hammerid" "6463744"}
-{"hammerid" "6463746"}
-{"hammerid" "6463748"}
-{"hammerid" "6463750"}
-{"hammerid" "6463752"}
-{"hammerid" "6463754"}
-{"hammerid" "6463756"}
-{"hammerid" "6463758"}
-{"hammerid" "6463760"}
-{"hammerid" "6463762"}
-{"hammerid" "6463764"}
-{"hammerid" "6463766"}
-{"hammerid" "6463768"}
-{"hammerid" "6463770"}
-{"hammerid" "6463772"}
-{"hammerid" "6463774"}
-
-; --- filter out bugged witches in 1v1
-
-filter:
-
 {
 	"targetname" "spawn_witch"
 }
 
-; --- Block jumping on gas station roof
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Remove out of bounds items (old version only)
+filter:
+{
+	"hammerid" "6463708"
+}
+{
+	"hammerid" "6463710"
+}
+{
+	"hammerid" "6463712"
+}
+{
+	"hammerid" "6463714"
+}
+{
+	"hammerid" "6463716"
+}
+{
+	"hammerid" "6463718"
+}
+{
+	"hammerid" "6463720"
+}
+{
+	"hammerid" "6463722"
+}
+{
+	"hammerid" "6463724"
+}
+{
+	"hammerid" "6463726"
+}
+{
+	"hammerid" "6463728"
+}
+{
+	"hammerid" "6463730"
+}
+{
+	"hammerid" "6463732"
+}
+{
+	"hammerid" "6463734"
+}
+{
+	"hammerid" "6463736"
+}
+{
+	"hammerid" "6463738"
+}
+{
+	"hammerid" "6463740"
+}
+{
+	"hammerid" "6463742"
+}
+{
+	"hammerid" "6463744"
+}
+{
+	"hammerid" "6463746"
+}
+{
+	"hammerid" "6463748"
+}
+{
+	"hammerid" "6463750"
+}
+{
+	"hammerid" "6463752"
+}
+{
+	"hammerid" "6463754"
+}
+{
+	"hammerid" "6463756"
+}
+{
+	"hammerid" "6463758"
+}
+{
+	"hammerid" "6463760"
+}
+{
+	"hammerid" "6463762"
+}
+{
+	"hammerid" "6463764"
+}
+{
+	"hammerid" "6463766"
+}
+{
+	"hammerid" "6463768"
+}
+{
+	"hammerid" "6463770"
+}
+{
+	"hammerid" "6463772"
+}
+{
+	"hammerid" "6463774"
+}
+{
+	"hammerid" "6496351"
+}
+{
+	"hammerid" "6496347"
+}
+{
+	"hammerid" "6531608"
+}
+{
+	"hammerid" "6496357"
+}
+{
+	"hammerid" "6496363"
+}
+{
+	"hammerid" "6496359"
+}
+{
+	"hammerid" "6496361"
+}
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
 add:
+; --- Ammo pile in the office by the silos
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "-1005 -7913 111"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from jumping on gas station roof
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1593 -13616 894"
@@ -64,3 +186,192 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+add:
+; --- Fix non-solid trees by the silos
+{
+	"classname" "prop_dynamic"
+	"origin" "-1237 -7354 97"
+	"angles" "0 220 0"
+	"model" "models/props_foliage/urban_tree_giant01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "355 -8630 97"
+	"angles" "0 213.5 0"
+	"model" "models/props_foliage/urban_tree_giant01_small.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+; --- Block jumping onto one of the trees
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1068 -7395 1273"
+	"mins" "-35 -35 -841"
+	"maxs" "35 35 841"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Clipping between truck and roof by the silos
+{
+	"classname" "env_physics_blocker"
+	"origin" "280 -8192 267"
+	"mins" "-3 -51 -5"
+	"maxs" "3 51 5"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "286 -8192 276"
+	"mins" "-3 -51 -4"
+	"maxs" "3 51 4"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder to get on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "7240 1747 -6.5"
+	"angles" "0 270 0"
+	"model" "*211"
+	"normal.x" "-1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to get on the awning in the construction site (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*213"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*214"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+; --- Infected ladder to climb on the generator room roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1721 1242 41"
+	"angles" "0 0 0"
+	"model" "*70"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the pipe outside the generator room (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1628 0 0"
+	"angles" "0 0 0"
+	"model" "*57"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the larger slanted roof by the silos (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-438 -1006 -4"
+	"angles" "0 0 0"
+	"model" "*64"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Fix a badly placed ladder by the office in the mill (all versions)
+modify:
+{
+	match:
+	{
+		"hammerid" "3484921"
+	}
+	insert:
+	{
+		"origin" "2 0 3"
+	}
+}
+
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/zonemod/maps/dprm3_sugarmill_b.cfg
+++ b/cfg/stripper/zonemod/maps/dprm3_sugarmill_b.cfg
@@ -1,5 +1,55 @@
-; --- Block jumping on gas station roof
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
 add:
+; --- Ammo pile in the train yard
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "455 -11656 198"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+; --- Ammo pile in the office by the silos
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "-1005 -7913 111"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block jumping on gas station roof
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1593 -13616 894"
@@ -16,3 +66,213 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+add:
+; --- Fix non-solid trees by the silos
+{
+	"classname" "prop_dynamic"
+	"origin" "-1237 -7354 97"
+	"angles" "0 220 0"
+	"model" "models/props_foliage/urban_tree_giant01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "355 -8630 97"
+	"angles" "0 213.5 0"
+	"model" "models/props_foliage/urban_tree_giant01_small.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+; --- Block jumping onto one of the trees
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1068 -7395 1273"
+	"mins" "-35 -35 -841"
+	"maxs" "35 35 841"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Clipping between truck and roof by the silos
+{
+	"classname" "env_physics_blocker"
+	"origin" "280 -8192 267"
+	"mins" "-3 -51 -5"
+	"maxs" "3 51 5"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "286 -8192 276"
+	"mins" "-3 -51 -4"
+	"maxs" "3 51 4"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder to get on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "3562 8946 -37"
+	"angles" "0 0 0"
+	"model" "*176"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+; --- Infected ladder to get on the awning in the construction site (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*272"
+	"normal.x" "-0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "341.87 -8565.88 11"
+	"angles" "0 90 0"
+	"model" "*273"
+	"normal.x" "-1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the generator room roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1721 1242 41"
+	"angles" "0 0 0"
+	"model" "*63"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the pipe outside the generator room (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "3668 -8701 16"
+	"angles" "0 180 0"
+	"model" "*53"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the larger slanted roof by the silos (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-438 -1006 -4"
+	"angles" "0 0 0"
+	"model" "*228"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the bridge by the bricks (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "10407 -7709 24"
+	"angles" "0 270 0"
+	"model" "*271"
+	"normal.x" "0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "10407 -7709 24"
+	"angles" "0 270 0"
+	"model" "*270"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Fix a badly placed ladder by the office in the mill (all versions)
+modify:
+{
+	match:
+	{
+		"hammerid" "3484921"
+	}
+	insert:
+	{
+		"origin" "2 0 3"
+	}
+}
+
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/zonemod/maps/dprm4_milltown_b.cfg
+++ b/cfg/stripper/zonemod/maps/dprm4_milltown_b.cfg
@@ -1,5 +1,34 @@
-; --- Block jumping on house by the playground
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
 add:
+; --- Block survivors from jumping on house by the playground
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1473 7605 958"
@@ -16,3 +45,169 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+modify:
+; --- Fix broken ladder on broken fence after the burger tank (newest version)
+{
+	match:
+	{
+		"hammerid" "1639791"
+	}
+	insert:
+	{
+		"origin" "0 4 0"
+	}
+}
+; --- Fix broken ladders on house by the playground (newest version)
+{
+	match:
+	{
+		"hammerid" "2591916"
+	}
+	insert:
+	{
+		"origin" "0 1 0"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "2591878"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix broken ladders on house by the playground (old version)
+; --- Move ladder to a different spot due to badly placed clip brush
+{
+	match:
+	{
+		"hammerid" "8007823"
+	}
+	insert:
+	{
+		"origin" "-70 0 0"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "8007814"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix broken ladder by garage sale (newest version)
+{
+	match:
+	{
+		"hammerid" "4273049"
+	}
+	insert:
+	{
+		"origin" "1 0 0"
+	}
+}
+; --- Fix broken infected ladder by the one-way drop house (old version) (credit: Wicket)
+add:
+{
+	"classname" "func_simpleladder"
+	"origin" "9905.00 2248.00 -88.00"
+	"angles" "0.00 90.00 0.00"
+	"model" "*64"
+	"normal.x" "0.86"
+	"normal.y" "0.00"
+	"normal.z" "-0.50"
+	"team" "2"
+	"rendermode" "10" ; --- On newest this is visible in an incorrect spot so hide it
+}
+; --- Infected ladder to climb on the house by the flower garden (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "1142 58 213"
+	"angles" "0 0 0"
+	"model" "*148"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the sugarmill saferoom roof (newest version only)
+{
+	"classname" "func_simpleladder"
+	"origin" "-1712 -1870 -28"
+	"angles" "0 270 0"
+	"model" "*92"
+	"normal.x" "0.89"
+	"normal.y" "0.00"
+	"normal.z" "-0.44"
+	"team" "2"
+}
+
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================

--- a/cfg/stripper/zonemod/maps/dprm5_milltown_escape.cfg
+++ b/cfg/stripper/zonemod/maps/dprm5_milltown_escape.cfg
@@ -10,6 +10,22 @@
 ; ==           PILL / ITEM / WEAPON SPAWNS           ==
 ; ==   Remove or change pill, item & weapon spawns   ==
 ; =====================================================
+; --- Pistols on the docks
+add:
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6933 7745 148"
+	"angles" "0 255 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
+{
+	"classname" "weapon_pistol_spawn"
+	"origin" "-6934 7761 148"
+	"angles" "0 270 -90"
+	"ammo" "999"
+	"spawnflags" "1"
+}
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -27,24 +43,6 @@
 ; ==                 EXPLOITS BLOCKED                ==
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
-add:
-; --- Block survivors from jumping on house by the playground
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1473 7605 958"
-	"mins" "-176 -376 -626"
-	"maxs" "176 376 626"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1817 7805 958"
-	"mins" "-168 -176 -626"
-	"maxs" "168 176 626"
-	"initialstate" "1"
-	"BlockType" "1"
-}
 
 ; =====================================================
 ; ==                  OUT OF BOUNDS                  ==
@@ -60,6 +58,48 @@ add:
 ; ==                 NUISANCE CHANGES                ==
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
+; --- Allow any infected to break the Save 4 Less store windows
+modify:
+{
+	match:
+	{
+		"targetname" "glass_1s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_2s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_3s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "glass_4s"
+	}
+	replace:
+	{
+		"BreakableType" "1"
+	}
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -104,6 +144,18 @@ add:
 ; ==              Add or change ladders              ==
 ; =====================================================
 modify:
+; --- Fix broken ladder on Self Storage building (old version)
+{
+	match:
+	{
+		"hammerid" "6996"
+	}
+	replace:
+	{
+		"normal.x" "-1.00"
+		"normal.y" "0.00"
+	}
+}
 ; --- Fix broken ladder on broken fence after the burger tank (newest version)
 {
 	match:
@@ -114,95 +166,6 @@ modify:
 	{
 		"origin" "0 4 0"
 	}
-}
-; --- Fix broken ladders on house by the playground (newest version)
-{
-	match:
-	{
-		"hammerid" "2591916"
-	}
-	insert:
-	{
-		"origin" "0 1 0"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "2591878"
-	}
-	insert:
-	{
-		"origin" "0 -1 0"
-	}
-}
-; --- Fix broken ladders on house by the playground (old version)
-; --- Move ladder to a different spot due to badly placed clip brush
-{
-	match:
-	{
-		"hammerid" "8007823"
-	}
-	insert:
-	{
-		"origin" "-70 0 0"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "8007814"
-	}
-	insert:
-	{
-		"origin" "0 -1 0"
-	}
-}
-; --- Fix broken ladder by garage sale (newest version)
-{
-	match:
-	{
-		"hammerid" "4273049"
-	}
-	insert:
-	{
-		"origin" "1 0 0"
-	}
-}
-; --- Fix broken infected ladder by the one-way drop house (old version) (credit: Wicket)
-add:
-{
-	"classname" "func_simpleladder"
-	"origin" "9905.00 2248.00 -88.00"
-	"angles" "0.00 90.00 0.00"
-	"model" "*64"
-	"normal.x" "0.86"
-	"normal.y" "0.00"
-	"normal.z" "-0.50"
-	"team" "2"
-	"rendermode" "10" ; --- On newest this is visible in an incorrect spot so hide it
-}
-; --- Infected ladder to climb on the house by the flower garden (newest version only)
-{
-	"classname" "func_simpleladder"
-	"origin" "1142 58 213"
-	"angles" "0 0 0"
-	"model" "*148"
-	"normal.x" "0.00"
-	"normal.y" "1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-; --- Infected ladder to climb on the sugarmill saferoom roof (newest version only)
-{
-	"classname" "func_simpleladder"
-	"origin" "-1712 -1870 -28"
-	"angles" "0 270 0"
-	"model" "*92"
-	"normal.x" "0.89"
-	"normal.y" "0.00"
-	"normal.z" "-0.44"
-	"team" "2"
 }
 
 

--- a/cfg/stripper/zonemod/maps/l4d_dbd2dc_the_mall.cfg
+++ b/cfg/stripper/zonemod/maps/l4d_dbd2dc_the_mall.cfg
@@ -123,6 +123,7 @@ modify:
 	{
 		"OnPressed" "eingangsture,Unlock,,41.05,-1"
 		"OnPressed" "eingangsture,Open,,42,-1"
+		"OnPressed" "eingangsture,SetBreakable,,42,-1"
 		"OnPressed" "director,PanicEvent,,4,-1"
 		"OnPressed" "cj_door_open,PlaySound,,42.1,-1"
 		"OnPressed" "girl_van,Start,,6,-1"


### PR DESCRIPTION
Zonemod update + Acemod RV version: 1.2

### Hard Rain: Downpour
* Hard Rain: Downpour has been updated to use the most recent version of the map
* Download the latest version here: https://cedapug.com/maps/downpour.zip

> **Server Owners:** Replace your Hard Rain: Downpour vpk and download with this.

#### Maps 1, 4 & 5
##### Latest Map Version Differences
* Gun spawns at the start of map 1 are infinite instead of single pickups
* More ammo pile spawns
* Layout changed in some key areas

##### Stripper Changes
* Fixed starting saferoom nav mesh issue, which prevented players from moving during ready up
* Added 2 pistol spawns in the saferoom
* Fixed various broken ladders
* Re-added some key ladders that were removed in the latest version
* Allowed all infected to break the windows in the Save 4 Less store

#### Maps 2 & 3
##### Latest Map Version Differences
* Some infected ladders added, removed or moved

##### Stripper Changes
* Re-added some key ladders that were removed in the latest version
* Added 2 new ladders
* Added 2 new ammo piles
* Fixed some non-solid trees

**Full Changelog**

1. [Milltown](https://github.com/Derpduck/L4D2-Comp-Stripper-Rework/wiki/Hard-Rain:-Downpour-1-Milltown)
2. [Sugarmill](https://github.com/Derpduck/L4D2-Comp-Stripper-Rework/wiki/Hard-Rain:-Downpour-2-Sugar-Mill)
3. [Sugarmill Return](https://github.com/Derpduck/L4D2-Comp-Stripper-Rework/wiki/Hard-Rain:-Downpour-3-Sugarmill-Return)
4. [Milltown Return](https://github.com/Derpduck/L4D2-Comp-Stripper-Rework/wiki/Hard-Rain:-Downpour-4-Milltown-Return)
5. [Milltown Escape](https://github.com/Derpduck/L4D2-Comp-Stripper-Rework/wiki/Hard-Rain:-Downpour-5-Milltown-Escape)

### Dark Carnival
#### Map 1
* Fixed collision issues with tree outside saferoom
* Removed the shrub wall on the small patch of land by the outhouse

#### Map 2
* Removed fence cover by the carousel after the one way drop

### The Parish
#### Map 2
* Removed platform on the right side of the park
* Removed an extra hedge on the right side of the park
* Removed an extra hedge on the left side of the park

### The Passing
#### Map 1
* Fixed issue with clipping on a crashed bus by the saferoom that blocked hittables
* Fixed hittable car that spawns inside a truck which could incap survivors when a boomer explodes near it

### Death Toll
#### Map 1
* Added a tree to cross between the cliffs by the bridge to get above the saferoom
* Adjusted clipping by the bridge where players could previously cross between the cliffs

### Dead Air
#### Map 3
* Added infected ladders onto pipes in the back of the construction site

### The Last Stand
#### Map 1
* Added a ladder for survivors to climb back up at the house one-way drop

### Dead Before Dawn
#### Map 2
* Fixed event door being unbreakable after the event is over

